### PR TITLE
Use newer import-images image

### DIFF
--- a/values/import-images/fedora-source-git-prod.yaml
+++ b/values/import-images/fedora-source-git-prod.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "369a9d1"
+  tag: "6c940e9"
 
 host: https://api.auto-prod.gi0n.p1.openshiftapps.com:6443
 


### PR DESCRIPTION
For the tags, see https://quay.io/repository/packit/import-images?tab=tags

For the fix the new image includes, see https://github.com/packit/deployment/commit/b97193df13850b3fd06eaa5f42fadd1a76830743

(packit-prod & stream-prod don't need the change)